### PR TITLE
typo in property

### DIFF
--- a/xeggex.py
+++ b/xeggex.py
@@ -786,7 +786,7 @@ class XeggeXClient():
             "ticker": ticker,
             "quantity": quantity,
             "address": address,
-            "paymentId": payment_id
+            "paymentid": payment_id
         }
         pop_none(data)
         return self.post(path, data)


### PR DESCRIPTION
It was typo error and memo not stored properly on create withdrawal.